### PR TITLE
Make building of ngtemplate's tests optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 PROJECT(ngtemplate)
 
+OPTION(NGT_BUILD_TESTS "build ngtemplate tests" ON)
+
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
@@ -38,46 +40,48 @@ TARGET_LINK_LIBRARIES(ngtemplate useful)
 ADD_EXECUTABLE(ngtembed ngtembed_tool.c ngtembed.c)
 TARGET_LINK_LIBRARIES(ngtembed useful ngtemplate)
 
-ENABLE_TESTING()
+IF (NGT_BUILD_TESTS)
+	ENABLE_TESTING()
 
-ADD_EXECUTABLE(template_test testing/template_test.c)
-TARGET_LINK_LIBRARIES(template_test useful ngtemplate)
+	ADD_EXECUTABLE(template_test testing/template_test.c)
+	TARGET_LINK_LIBRARIES(template_test useful ngtemplate)
 
-ADD_EXECUTABLE(ngtembed_test testing/ngtembed_test.c ngtembed.c)
-TARGET_LINK_LIBRARIES(ngtembed_test useful ngtemplate)
+	ADD_EXECUTABLE(ngtembed_test testing/ngtembed_test.c ngtembed.c)
+	TARGET_LINK_LIBRARIES(ngtembed_test useful ngtemplate)
 
-SET(NGT_TESTDIR ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
+	SET(NGT_TESTDIR ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
 
-MACRO(ADD_TEMPLATE_TEST NUMBER)
-	ADD_TEST(
-		template_${NUMBER} 
-		${EXECUTABLE_OUTPUT_PATH}/template_test
-		${NGT_TESTDIR}/template_${NUMBER}.tst
-		${NGT_TESTDIR}/template_${NUMBER}.bmk
-	)
-ENDMACRO(ADD_TEMPLATE_TEST)
+	MACRO(ADD_TEMPLATE_TEST NUMBER)
+		ADD_TEST(
+			template_${NUMBER} 
+			${EXECUTABLE_OUTPUT_PATH}/template_test
+			${NGT_TESTDIR}/template_${NUMBER}.tst
+			${NGT_TESTDIR}/template_${NUMBER}.bmk
+		)
+	ENDMACRO(ADD_TEMPLATE_TEST)
 
-MACRO(ADD_TEMPLATE_TEST_1 NUMBER EXTRA_ARG)
-	ADD_TEST(
-		template_${NUMBER} 
-		${EXECUTABLE_OUTPUT_PATH}/template_test
-		${NGT_TESTDIR}/template_${NUMBER}.tst
-		${NGT_TESTDIR}/template_${NUMBER}.bmk
-		${EXTRA_ARG}
-	)
-ENDMACRO(ADD_TEMPLATE_TEST_1)
+	MACRO(ADD_TEMPLATE_TEST_1 NUMBER EXTRA_ARG)
+		ADD_TEST(
+			template_${NUMBER} 
+			${EXECUTABLE_OUTPUT_PATH}/template_test
+			${NGT_TESTDIR}/template_${NUMBER}.tst
+			${NGT_TESTDIR}/template_${NUMBER}.bmk
+			${EXTRA_ARG}
+		)
+	ENDMACRO(ADD_TEMPLATE_TEST_1)
 
-ADD_TEMPLATE_TEST(0)
-ADD_TEMPLATE_TEST(1)
-ADD_TEMPLATE_TEST(2)
-ADD_TEMPLATE_TEST(3)
-ADD_TEMPLATE_TEST(4)
-ADD_TEMPLATE_TEST(5)
-ADD_TEMPLATE_TEST_1(6 ${NGT_TESTDIR}/template_6.subtemplate)
-ADD_TEMPLATE_TEST(7)
-ADD_TEMPLATE_TEST(8)
-ADD_TEMPLATE_TEST(9)
-ADD_TEMPLATE_TEST(10)
-ADD_TEMPLATE_TEST(11)
-ADD_TEMPLATE_TEST(12)
-ADD_TEST(ngtembed ${EXECUTABLE_OUTPUT_PATH}/ngtembed_test ${NGT_TESTDIR}/ngtembed_0.tst=test0 ${NGT_TESTDIR}/ngtembed_1.tst=test1 ${NGT_TESTDIR}/ngtembed_2.tst=test2 ${NGT_TESTDIR}/ngtembed.bmk)
+	ADD_TEMPLATE_TEST(0)
+	ADD_TEMPLATE_TEST(1)
+	ADD_TEMPLATE_TEST(2)
+	ADD_TEMPLATE_TEST(3)
+	ADD_TEMPLATE_TEST(4)
+	ADD_TEMPLATE_TEST(5)
+	ADD_TEMPLATE_TEST_1(6 ${NGT_TESTDIR}/template_6.subtemplate)
+	ADD_TEMPLATE_TEST(7)
+	ADD_TEMPLATE_TEST(8)
+	ADD_TEMPLATE_TEST(9)
+	ADD_TEMPLATE_TEST(10)
+	ADD_TEMPLATE_TEST(11)
+	ADD_TEMPLATE_TEST(12)
+	ADD_TEST(ngtembed ${EXECUTABLE_OUTPUT_PATH}/ngtembed_test ${NGT_TESTDIR}/ngtembed_0.tst=test0 ${NGT_TESTDIR}/ngtembed_1.tst=test1 ${NGT_TESTDIR}/ngtembed_2.tst=test2 ${NGT_TESTDIR}/ngtembed.bmk)
+ENDIF(NGT_BUILD_TESTS)


### PR DESCRIPTION
When ngtemplate is used as a build dependency it is useful to disable
building tests to speed up the build process.  Set the NGT_BUILD_TESTS
option to control this.  By default it is ON (i.e. tests are built) so
that the previous default is maintainted.

Setting the option may be done from a CMakeLists.txt file that lists
ngtemplate as a dependency:

```
SET(NGT_BUILD_TESTS OFF)
```

It may also be set on the command line of cmake

```
cmake -DNGT_BUILD_TESTS=OFF ...
```
