### PR TITLE
fix build error of pull request #5

### DIFF
--- a/src/ngtembed.c
+++ b/src/ngtembed.c
@@ -50,7 +50,7 @@ int ngt_embed(const char* code_template, FILE* out, int argc, char** argv)  {
     ngt_add_modifier(tpl, "breakup_lines", _breakup_lines_modifier_cb);
     ngt_set_delimiters(tpl, "@", "@");
     ngt_set_dictionary(tpl, dict);
-    tpl->template = (char*)code_template;
+    tpl->tmpl = (char*)code_template;
     
     for (i = 1; i < argc; i++)  {
         char* p;

--- a/src/testing/template_test.c
+++ b/src/testing/template_test.c
@@ -235,7 +235,7 @@ DEFINE_TEST_FUNCTION    {
     line = 1;
     
     ngt_load_from_file(tpl, in);
-    read_in_dictionary(dict, tpl->template, &line, 0);
+    read_in_dictionary(dict, tpl->tmpl, &line, 0);
     ngt_set_include_cb(dict, "Callback_Template", get_template_cb, cleanup_template_cb);
         
     ngt_add_modifier(tpl, "modifier", modifier_cb);


### PR DESCRIPTION
It seems that pull request https://github.com/breckinloggins/ngtemplate/pull/5 can't build.

```
$ make
[  3%] Building C object libuseful/CMakeFiles/useful.dir/platform.c.o
[  7%] Building C object libuseful/CMakeFiles/useful.dir/hashtable.c.o
[ 11%] Building C object libuseful/CMakeFiles/useful.dir/list.c.o
[ 14%] Building C object libuseful/CMakeFiles/useful.dir/stringbuilder.c.o
[ 18%] Building C object libuseful/CMakeFiles/useful.dir/optin.c.o
Linking C static library libuseful.a
[ 18%] Built target useful
[ 22%] Building C object CMakeFiles/ngtemplate.dir/internal.c.o
[ 25%] Building C object CMakeFiles/ngtemplate.dir/stdenv.c.o
[ 29%] Building C object CMakeFiles/ngtemplate.dir/ngtemplate.c.o
Linking C static library libngtemplate.a
[ 29%] Built target ngtemplate
[ 33%] Building C object CMakeFiles/ngtembed.dir/ngtembed_tool.c.o
[ 37%] Building C object CMakeFiles/ngtembed.dir/ngtembed.c.o
ngtemplate/src/ngtembed.c: In function 'ngt_embed':
ngtemplate/src/ngtembed.c:53:8: error: 'ngt_template' has no member named 'template'
make[2]: *** [CMakeFiles/ngtembed.dir/ngtembed.c.o] Error 1
make[1]: *** [CMakeFiles/ngtembed.dir/all] Error 2
make: *** [all] Error 2
```
